### PR TITLE
Implement lic_2

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -1,4 +1,4 @@
-from math import sqrt
+from math import sqrt, acos, pi
 
 def cmv(parameters, points):
     cmv = [False] * 15
@@ -33,8 +33,30 @@ def lic_1(parameters, points):
     pass
 
 def lic_2(parameters, points):
-    # TODO: Implement
-    pass
+    for i in range(0, len(points)-2):
+        a_x_distance = abs(points[i+1][0] - points[i+2][0])
+        a_y_distance = abs(points[i+1][1] - points[i+2][1])
+        a = abs(sqrt(a_x_distance**2 + a_y_distance**2))
+
+        b_x_distance = abs(points[i][0] - points[i+1][0])
+        b_y_distance = abs(points[i][1] - points[i+1][1])
+        b = abs(sqrt(b_x_distance**2 + b_y_distance**2))
+
+        c_x_distance = abs(points[i][0] - points[i+2][0])
+        c_y_distance = abs(points[i][1] - points[i+2][1])
+        c = abs(sqrt(c_x_distance**2 + c_y_distance**2))
+
+        # Not satisfied if either the first point or
+        # the last point (or both) coincides with the vertex
+        if a == 0 or b == 0:
+            continue
+        
+        # Use the law of cosines
+        angle = acos((a**2 + b**2 - c**2) / (2*a*b))
+
+        if angle < pi - parameters["epsilon"]:
+            return True
+    return False
 
 def lic_3(parameters, points):
     # TODO: Implement

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -58,3 +58,78 @@ def test_lic_0_false():
     points = [(0.0, 0.0), (1.0, 1.0), (1.0, 3.0)]
     result = lic_0(parameters, points)
     assert(not result)
+
+def test_lic_2_true():
+    """
+    Test that lic_2 returns true when angle < (PI-EPSILON) (or equivalently outer angle > (PI+EPSILON))
+    """
+    parameters = {
+        "epsilon": pi/2
+    }
+    points = [(0.0, 0.0), (1.0, 0.0), (0, 1.0)] # pi/4 angle
+    result = lic_2(parameters, points)
+    assert(result)
+
+
+def test_lic_2_false():
+    """
+    Test that lic_2 returns false when angle > (PI-EPSILON) (or equivalently outer angle < (PI+EPSILON))
+    """
+    parameters = {
+        "epsilon": pi
+    }
+    points = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)] # pi/2 angle
+    result = lic_2(parameters, points)
+    assert(not result)
+
+def test_lic_2_coinciding_vertex_1():
+    """
+    Test that lic_2 returns false when the first point in one sequence
+    coincides with the vertex and no other sequence of consecutive points
+    satisfies angle < (PI-EPSILON)
+    """
+    parameters = {
+        "epsilon": pi
+    }
+    points = [(0.0, 0.0), (0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]
+    result = lic_2(parameters, points)
+    assert(not result)
+
+def test_lic_2_coinciding_vertex_2():
+    """
+    Test that lic_2 returns true when the first point in one sequence
+    coincides with the vertex and another sequence of consecutive points
+    satisfies angle < (PI-EPSILON)
+    """
+    parameters = {
+        "epsilon": pi/2
+    }
+    points = [(0.0, 0.0), (0.0, 0.0), (1.0, 0.0), (0, 1.0)]
+    result = lic_2(parameters, points)
+    assert(result)
+
+def test_lic_2_coinciding_vertex_3():
+    """
+    Test that lic_2 returns false when the last point in one sequence
+    coincides with the vertex and no other sequence of consecutive points
+    satisfies angle < (PI-EPSILON)
+    """
+    parameters = {
+        "epsilon": pi
+    }
+    points = [(-1.0, 0.0), (0.0, 0.0), (0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]
+    result = lic_2(parameters, points)
+    assert(not result)
+
+def test_lic_2_coinciding_vertex_4():
+    """
+    Test that lic_2 returns true when the last point in one sequence
+    coincides with the vertex and another sequence of consecutive points
+    satisfies angle < (PI-EPSILON)
+    """
+    parameters = {
+        "epsilon": pi/2
+    }
+    points = [(-1.0, 0.0), (0.0, 0.0), (0.0, 0.0), (1.0, 0.0), (0, 1.0)]
+    result = lic_2(parameters, points)
+    assert(result)


### PR DESCRIPTION
This adds an implementation for the lic_2 function. It returns true when the angle satisfies angle > (PI-EPSILON) (or equivalently when the outer angle satisfies angle < (PI+EPSILON)).

This also adds a set of unit tests. There is a testcase for when the condition is true and another for when it is false. There are also 4 test cases that handle the edge case when the first or the last points in a sequence coincide with the vertex.

Fixes #6