### PR TITLE
Implement lic_1

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -29,8 +29,38 @@ def lic_0(parameters, points):
     return False
 
 def lic_1(parameters, points):
-    # TODO: Implement
-    pass
+    """
+    Checks whether any three data points fits inside a circle
+    with the radius specified in parameters["radius1"]
+    """
+    for i in range(len(points) - 2):
+        p1 = points[i]
+        p2 = points[i+1]
+        p3 = points[i+2]
+
+        a = dist(p1, p2)
+        b = dist(p1, p3)
+        c = dist(p2, p3)
+
+        # Semi-perimeter
+        s = (a+b+c)/2
+
+        # Heron's formula
+        area = sqrt(s*(s-a)*(s-b)*(s-c))
+        
+        # If the area is zero, then the triangle is degenerate, i.e. a+b=c for a≤b≤c
+        if area == 0.0:
+            if max(a, b, c) > 2*parameters["radius1"]:
+                return True
+            else:
+                continue
+        
+        # All other triangles
+        circumradius = a*b*c/(4*area)
+
+        if circumradius > parameters["radius1"]:
+            return True
+    return False
 
 def lic_2(parameters, points):
     for i in range(0, len(points)-2):

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -59,6 +59,54 @@ def test_lic_0_false():
     result = lic_0(parameters, points)
     assert(not result)
 
+def test_lic_1_true():
+    """
+    Test that lic_1 returns true if any three consecutive points cannot all be contained in a circle with
+    the specified radius
+    """
+    parameters = {
+        "radius1": 1.0
+    }
+    points = [(2.0, 0.0), (0.0, 2.0), (3.0, 0.0)]
+    result = lic_1(parameters, points)
+    assert(result)
+
+def test_lic_1_false():
+    """
+    Test that lic_1 returns false if all sequences of three consecutive points can be contained in a circle
+    with the specified radius
+    """
+    parameters = {
+        "radius1": 1.0
+    }
+    points = [(1.0, 2.0), (2.0, 1.0), (1.5, 1.0)]
+    result = lic_1(parameters, points)
+    assert(not result)
+
+def test_lic_degenerate_triangle_true():
+    """
+    Test that lic_1 returns true if three consecutive points that form a degenerate triangle
+    (i.e. a+b=c for a≤b≤c) cannot all be contained in a circle with the specified radius
+    """
+    parameters = {
+        "radius1": 1.0
+    }
+    points = [(2.0, 0.0), (0.0, 2.0), (1.0, 0.0)]
+    result = lic_1(parameters, points)
+    assert(result)
+
+def test_lic_degenerate_triangle_false():
+    """
+    Test that lic_1 returns false if three consecutive points that form a degenerate triangle and
+    all sequences of three consecutive points can be contained in a circle with the specified radius
+    """
+    parameters = {
+        "radius1": 1.0
+    }
+    points = [(1.0, 0.0), (0.0, 0.0), (-1.0, 0.0)]
+    result = lic_1(parameters, points)
+    assert(not result)
+
 def test_lic_2_true():
     """
     Test that lic_2 returns true when angle < (PI-EPSILON) (or equivalently outer angle > (PI+EPSILON))


### PR DESCRIPTION
This adds an implementation for the lic_1 function. It returns true when any three consecutive data points cannot all be contained inside a circle with a radius of RADIUS1. This also adds 4 unit tests that cover the case when the statement is true and false both for points that form non-degenerate and degenerate triangles.

Fixes #5