### PR TITLE
Implement lic_5

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -156,8 +156,13 @@ def lic_4(parameters, points):
     return False
 
 def lic_5(parameters, points):
-    # TODO: Implement
-    pass
+    """
+    Checks whether there exists two consecutive points (x1, y1) (x2, y2) such that x2 - x1 < 0
+    """
+    for i in range(0, len(points)-1):
+        if points[i+1][0] - points[i][0] < 0:
+            return True
+    return False
 
 def lic_6(parameters, points):
     # TODO: Implement

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -314,3 +314,21 @@ def test_lic_4_false_not_consecutive():
     points = [(0.0, 0.0), (-1.0, -1.0), (0.0, 0.0), (-1.0, -1.0)]
     result = lic_4(parameters, points)
     assert not result
+
+def test_lic_5_true():
+    """
+    Tests that lic_5 returns true when two consecutive points (x1, y1) (x2, y2) exist such that x2 - x1 < 0
+    """
+    parameters = {}
+    points = [(1.0, 0.0), (0.0, 0.0)]
+    result = lic_5(parameters, points)
+    assert(result)
+
+def test_lic_6_true():
+    """
+    Tests that lic_5 returns false when no consecutive points (x1, y1) (x2, y2) exist such that x2 - x1 < 0
+    """
+    parameters = {}
+    points = [(0.0, 0.0), (1.0, 0.0)]
+    result = lic_5(parameters, points)
+    assert(not result)


### PR DESCRIPTION
This adds an implementation for the lic_5 function. It returns true when two consecutive points (x1, y1) (x2, y2) exist such that x2 - x1 < 0 and false otherwise. Two unit-tests have also been added covering the true and false case.

Fixes #10