### PR TITLE
Implement lic_6

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -160,8 +160,39 @@ def lic_5(parameters, points):
     pass
 
 def lic_6(parameters, points):
-    # TODO: Implement
-    pass
+    """
+    Checks whether or not there exists at least one set of [n_pts] consecutive data points such that at least one point 
+    lies at a distance greater than [dist] to the line joining the first and the last point.
+    If the first and last point are the same, then it will check whether or not *all* other points lie at a distance
+    greater than [dist] to the first/last point. 
+    """
+    n_pts = parameters["n_pts"]
+    dist_p = parameters["dist"]
+
+    if len(points) < n_pts or len(points) < 3:
+        return False
+
+    for i in range(len(points)-n_pts+1):
+        consecutive_points = []
+        for j in range(n_pts):
+            consecutive_points.append(points[i+j])
+        p1 = consecutive_points[0]
+        p2 = consecutive_points[-1]
+        line = dist(p1, p2)
+        all_points_greater_than_dist = True # used in case p1 and p2 are the same
+        for p in consecutive_points[1:-1]:
+            if line == 0:
+                dist_to_point = dist(p, p1)
+                if dist_to_point < dist_p:
+                    all_points_greater_than_dist = False
+                    break
+            else:
+                dist_to_line = abs((p2[0]-p1[0])*(p1[1]-p[1]) - (p1[0]-p[0])*(p2[1]-p1[1]))/line
+                if dist_to_line > dist_p:
+                    return True
+        if line == 0 and all_points_greater_than_dist:
+            return True
+    return False
 
 def lic_7(parameters, points):
     # TODO: Implement

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -314,3 +314,67 @@ def test_lic_4_false_not_consecutive():
     points = [(0.0, 0.0), (-1.0, -1.0), (0.0, 0.0), (-1.0, -1.0)]
     result = lic_4(parameters, points)
     assert not result
+
+def test_lic_6_true():
+    """
+    Tests that lic_6 returns true when there is one set of three consecutive points with one point that lies
+    at a distance greater than [dist] from the line joining the other two
+    """
+    parameters = {
+        "n_pts": 3,
+        "dist": 1
+    }
+    points = [(-2.0, -2.0), (-1.0, 0.0), (0.0, 5.0), (1.0, 0.0)]
+    result = lic_6(parameters, points)
+    assert result
+
+def test_lic_6_true_coinciding_point():
+    """
+    Tests that lic_6 returns true when the first and last points coincide and each other consecutive point
+    lies at a distance greater than [dist] to the coinciding point
+    """
+    parameters = {
+        "n_pts": 4,
+        "dist": 1
+    }
+    points = [(0.0, 0.0), (-2.0, 1.0), (1.0, 5.0), (0.0, 0.0)]
+    result = lic_6(parameters, points)
+    assert result
+
+def test_lic_6_false():
+    """
+    Tests that lic_6 returns false when there is no point that lies at a distance greater than [dist]
+    to the line joining the first and last points
+    """
+    parameters = {
+        "n_pts": 4,
+        "dist": 5
+    }
+    points = [(-2.0, 0.0), (-1.0, 1.0), (0.0, 3.0), (2.0, 0.0)]
+    result = lic_6(parameters, points)
+    assert not result
+
+def test_lic_6_false_too_few_points():
+    """
+    Tests that lic_6 returns false when there are less than three points
+    """
+    parameters = {
+        "n_pts": 4,
+        "dist": 5
+    }
+    points = [(-2.0, 0.0), (-1.0, 1.0)]
+    result = lic_6(parameters, points)
+    assert not result
+
+def test_lic_6_false_coinciding_point():
+    """
+    Tests that lic_6 returns false when the first and last points coincide and not all points lie at a 
+    distance greater than [dist] to the coinciding point
+    """
+    parameters = {
+        "n_pts": 4,
+        "dist": 5
+    }
+    points = [(0.0, 0.0), (-1.0, 1.0), (15.0, 15.0), (0.0, 0.0)]
+    result = lic_6(parameters, points)
+    assert not result


### PR DESCRIPTION
This implements the lic_6 function that checks whether or not there is at least one point among [n_pts] consecutive ones that lie at a distance greater than [dist] from the line joining the first and last points of the set. Alternatively, if the first and last points coincide, it will check if *all* other points lie at a distance greater than [dist] to the first/last point.

Also adds both positive and negative unit tests for both scenarios.

Fixes #11