### PR TITLE
Implement lic_7

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -164,8 +164,17 @@ def lic_6(parameters, points):
     pass
 
 def lic_7(parameters, points):
-    # TODO: Implement
-    pass
+    """
+    Checks whether or not there exists two points separated by [k_pts] consecutive points
+    that are more than [length1] units apart
+    """
+    k_pts = parameters["k_pts"]
+    length1 = parameters["length1"]
+
+    for i in range(len(points)-k_pts-1):
+        if dist(points[i], points[i+k_pts+1]) > length1:
+            return True
+    return False
 
 def lic_8(parameters, points):
     # TODO: Implement

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -314,3 +314,53 @@ def test_lic_4_false_not_consecutive():
     points = [(0.0, 0.0), (-1.0, -1.0), (0.0, 0.0), (-1.0, -1.0)]
     result = lic_4(parameters, points)
     assert not result
+
+def test_lic_7_true():
+    """
+    Tests that lic_7 returns true when there are two points separated by [k_pts] consecutive points
+    that lie at a distance greater than [length1] units apart
+    """
+    parameters = {
+        "length1": 1,
+        "k_pts": 1
+    }
+    points = [(0.0, 0.0), (-1.0, -1.0), (2.0, 0.0)]
+    result = lic_7(parameters, points)
+    assert result
+
+def test_lic_7_false():
+    """
+    Tests that lic_7 returns false when there are no two points separated by [k_pts] consecutive points
+    that lie at a distance greater than [length1] units apart
+    """
+    parameters = {
+        "length1": 1,
+        "k_pts": 2
+    }
+    points = [(0.0, 0.0), (-1.0, -1.0), (2.0, 0.0)]
+    result = lic_7(parameters, points)
+    assert not result
+
+def test_lic_7_false_distance_too_small():
+    """
+    Tests that lic_7 returns false when the points lie at a distance smaller than [length1]
+    """
+    parameters = {
+        "length1": 10,
+        "k_pts": 1
+    }
+    points = [(0.0, 0.0), (-1.0, -1.0), (2.0, 0.0)]
+    result = lic_7(parameters, points)
+    assert not result
+
+def test_lic_7_too_few_points():
+    """
+    Tests that lic_7 returns false when there are less than 3 points
+    """
+    parameters = {
+        "length1": 1,
+        "k_pts": 1
+    }
+    points = [(0.0, 0.0), (-1.0, -1.0)]
+    result = lic_7(parameters, points)
+    assert not result


### PR DESCRIPTION
This implements the lic_7 function that checks whether or not there
is at least one pair of points, separated by [k_pts] consecutive
points, that lie more than [length1] units apart.

Also adds a couple of unit tests.

Fixes #12