### PR TITLE
Add and implement pum function

### DIFF
--- a/pum.py
+++ b/pum.py
@@ -9,5 +9,5 @@ def pum(lcm, cmv):
                 case "ORR":
                     pum[i][j] = cmv[i] or cmv[j]
                 case "NOTUSED":
-                    pum[i][j] = False
+                    pum[i][j] = True
     return pum

--- a/pum.py
+++ b/pum.py
@@ -1,0 +1,13 @@
+def pum(lcm, cmv):
+    pum = [[False for _ in range(len(lcm[0]))] for _ in range(len(lcm))]
+    for i in range(len(lcm)):
+        for j in range(len(lcm[i])):
+            operator = lcm[i][j]
+            match operator:
+                case "ANDD":
+                    pum[i][j] = cmv[i] and cmv[j]
+                case "ORR":
+                    pum[i][j] = cmv[i] or cmv[j]
+                case "NOTUSED":
+                    pum[i][j] = False
+    return pum

--- a/test_pum.py
+++ b/test_pum.py
@@ -1,0 +1,42 @@
+from pum import *
+
+def test_pum_andd():
+    """
+    Tests that pum returns a 15x15 vector with correct values when the ANDD operator is used in the lcm.
+    When both cmv[i] and cmv[j] are true, pum[i][j] should be true. If not, then pum[i][j] should be false.
+    """
+    lcm = [["ANDD" for _ in range(15)] for _ in range(15)]
+    cmv = [True, False, True, False, True, False, True, False, True, False, True, False, True, False, True]
+    result = pum(lcm, cmv)
+    for i in range(len(cmv)):
+        for j in range(len(cmv)):
+            if i % 2 == 0 and j % 2 == 0:
+                assert(result[i][j])
+            else:
+                assert(not result[i][j])
+
+def test_pum_orr():
+    """
+    Tests that pum returns a 15x15 vector with correct values when the ORR operator is used in the lcm.
+    When neither cmv[i] nor cmv[j] are true, pum[i][j] should be false. Otherwise, pum[i][j] should be true.
+    """
+    lcm = [["ORR" for _ in range(15)] for _ in range(15)]
+    cmv = [True, False, True, False, True, False, True, False, True, False, True, False, True, False, True]
+    result = pum(lcm, cmv)
+    for i in range(len(cmv)):
+        for j in range(len(cmv)):
+            if i % 2 == 1 and j % 2 == 1:
+                assert(not result[i][j])
+            else:
+                assert(result[i][j])
+
+def test_pum_notused():
+    """
+    Tests that pum correctly returns a 15x15 vector filled with the boolean false when the NOTUSED operator
+    is the only operator used in the lcm.
+    """
+    lcm = [["NOTUSED" for _ in range(15)] for _ in range(15)]
+    cmv = [True, False, True, False, True, False, True, False, True, False, True, False, True, False, True]
+    result = pum(lcm, cmv)
+    expected = [[False] * 15] * 15
+    assert(result == expected)

--- a/test_pum.py
+++ b/test_pum.py
@@ -38,5 +38,5 @@ def test_pum_notused():
     lcm = [["NOTUSED" for _ in range(15)] for _ in range(15)]
     cmv = [True, False, True, False, True, False, True, False, True, False, True, False, True, False, True]
     result = pum(lcm, cmv)
-    expected = [[False] * 15] * 15
+    expected = [[True] * 15] * 15
     assert(result == expected)


### PR DESCRIPTION
This adds a a function for calculating the Preliminary Unlocking Matrix (PUM) based on the contents of the Conditions Met Vector (CMV) and Logical Connector Matrix (LCM). Each element PUM[i, j] is result of applying the boolean operator contained in LCM[i, j] to CMV[i] and CMV[j]. If PUM[i, j] is NOTUSED, then the element is set to false.

Three unit tests have also been added that check that each operator works correctly.

Fixes #28