### PR TITLE
Implement lic_13

### DIFF
--- a/cmv.py
+++ b/cmv.py
@@ -248,10 +248,54 @@ def lic_12(parameters, points):
             if long_points and short_points:
                 return True
     return False
-    
+
 def lic_13(parameters, points):
-    # TODO: Implement
-    pass
+    """
+    Checks whether both the following conditions are true:
+    - any three points with A_PTS and B_PTS consecutive intervening points cannot all be contained in a circle with radius RADIUS1
+    - any three points with A_PTS and B_PTS consecutive intervening points cannot all be contained in a circle with radius RADIUS2
+    If they are, return true. If they are not, return false.
+    """
+    if len(points) < 5:
+        return False
+    a_pts = parameters["a_pts"]
+    b_pts = parameters["b_pts"]
+    radius1 = parameters["radius1"]
+    radius2 = parameters["radius2"]
+    def helper(radius):
+        """
+        Checks whether any three points with A_PTS and B_PTS consecutive intervening points
+        cannot all be contained in a circle with the specified radius
+        """
+        for i in range(len(points) - 2 - a_pts - b_pts):
+            p1 = points[i]
+            p2 = points[i+1+a_pts]
+            p3 = points[i+2+a_pts+b_pts]
+
+            a = dist(p1, p2)
+            b = dist(p1, p3)
+            c = dist(p2, p3)
+
+            # Semi-perimeter
+            s = (a+b+c)/2
+
+            # Heron's formula
+            area = sqrt(s*(s-a)*(s-b)*(s-c))
+            
+            # If the area is zero, then the triangle is degenerate, i.e. a+b=c for a≤b≤c
+            if area == 0.0:
+                if max(a, b, c) > 2*radius:
+                    return True
+                else:
+                    continue
+            
+            # All other triangles
+            circumradius = a*b*c/(4*area)
+
+            if circumradius > radius:
+                return True
+        return False
+    return helper(radius1) and helper(radius2)
 
 def lic_14(parameters, points):
     # TODO: Implement

--- a/test_cmv.py
+++ b/test_cmv.py
@@ -452,3 +452,50 @@ def test_lic_12():
     parameters = {"k_pts": 5, "length1": 0.5, "length2": 10.0}
     result = lic_12(parameters, points)
     assert result == True, f"Expected True but got {result}"
+
+def test_lic_13_true():
+    """
+    Tests that lic_13 returns true if both the following conditions are true:
+    - any three points with A_PTS and B_PTS consecutive intervening points cannot all be contained in a circle with radius RADIUS1
+    - any three points with A_PTS and B_PTS consecutive intervening points cannot all be contained in a circle with radius RADIUS2
+    """
+    parameters = {
+        "radius1": 0.5,
+        "radius2": 1.0,
+        "a_pts": 1,
+        "b_pts": 1
+    }
+    points = [(2.0, 0.0), (0.0, 0.0), (0.0, 2.0), (0.0, 0.0), (3.0, 0.0)]
+    result = lic_13(parameters, points)
+    assert(result)
+
+def test_lic_13_false_1():
+    """
+    Tests that lic_13 returns false if any three points with A_PTS and B_PTS intervening points can all be contained
+    in a circle with the radius RADIUS1
+    """
+    parameters = {
+        "radius1": 10.0,
+        "radius2": 1.0,
+        "a_pts": 2,
+        "b_pts": 2
+    }
+    points = [(2.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 2.0), (0.0, 0.0), (0.0, 0.0), (3.0, 0.0)]
+    result = lic_13(parameters, points)
+    assert(not result)
+
+def test_lic_13_false_2():
+    """
+    Tests that lic_13 returns false if both:
+    - any three points with A_PTS and B_PTS consecutive intervening points can all be contained in a circle with radius RADIUS1
+    - any three points with A_PTS and B_PTS consecutive intervening points can all be contained in a circle with radius RADIUS2
+    """
+    parameters = {
+        "radius1": 10.0,
+        "radius2": 10.0,
+        "a_pts": 3,
+        "b_pts": 1
+    }
+    points = [(2.0, 0.0), (0.0, 0.0), (0.0, 0.0), (25.0, 25.0), (0.0, 2.0), (0.0, 0.0), (3.0, 0.0)]
+    result = lic_13(parameters, points)
+    assert(not result)


### PR DESCRIPTION
This adds an implementation for the lic_13 function that checks whether both of the following conditions are true:
- any three points with A_PTS and B_PTS consecutive intervening points cannot all be contained in a circle with radius RADIUS1
- any three points with A_PTS and B_PTS consecutive intervening points cannot all be contained in a circle with radius RADIUS2 If they both are true, it returns true. Otherwise, it returns false.

Fixes #16